### PR TITLE
Sending authapi.notify log to an email

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -43,6 +43,7 @@ config:
 
   # sentry
   sentry_port: 9090
+  sentry_admin_user: 'admin@agoravoting.com'
   sentry_db_password: '<PASSWORD>'
   sentry_admin_password: '<PASSWORD>'
 

--- a/config.yml
+++ b/config.yml
@@ -46,6 +46,13 @@ config:
   sentry_db_password: '<PASSWORD>'
   sentry_admin_password: '<PASSWORD>'
 
+  # Sending the code sms and email log to an email
+  sentry_msg_log: False
+  # the log receiver
+  sentry_msg_log_email: log@agoravoting.com
+  # the log sender
+  authapi_server_email: log@agoravoting.com
+
   # Authorities
 
   authorities:

--- a/doc/agora.config.yml
+++ b/doc/agora.config.yml
@@ -43,6 +43,7 @@ config:
 
   # sentry
   sentry_port: 9090
+  sentry_admin_user: 'admin@agoravoting.com'
   sentry_db_password: 'secret-password'
   sentry_admin_password: 'secret-password'
 

--- a/doc/agora.config.yml
+++ b/doc/agora.config.yml
@@ -46,6 +46,13 @@ config:
   sentry_db_password: 'secret-password'
   sentry_admin_password: 'secret-password'
 
+  # Sending the code sms and email log to an email
+  sentry_msg_log: False
+  # the log receiver
+  sentry_msg_log_email: log@agoravoting.com
+  # the log sender
+  authapi_server_email: log@agoravoting.com
+
   # Authorities
 
   authorities:

--- a/sentry/sentry.yml
+++ b/sentry/sentry.yml
@@ -28,4 +28,6 @@
   sudo_user: sentry
   shell: /home/sentry/venv/bin/sentry --config=/home/sentry/sentry.conf.py createuser --no-input --email='{{ config.sentry_admin_user }}' --superuser --password='{{ config.sentry_admin_password }}'
   register: command_result
-  failed_when: "'already exists' not in command_result.stderr"
+  failed_when:
+    - "'already exists' not in command_result.stderr"
+    - "command_result.rc != 0"

--- a/sentry/sentry.yml
+++ b/sentry/sentry.yml
@@ -11,7 +11,7 @@
 - name: Sentry, Create Database User
   sudo: true
   sudo_user: postgres
-  postgresql_user: user=sentry password="{{config.sentry_db_password}}" port=5432
+  postgresql_user: user=sentry password='{{config.sentry_db_password}}' port=5432
 
 - name: Sentry, Create Database
   sudo: true
@@ -26,4 +26,6 @@
 - name: Sentry, creating the first user
   sudo: true
   sudo_user: sentry
-  shell: /home/sentry/venv/bin/sentry --config=/home/sentry/sentry.conf.py createuser --no-input --email=admin@agoravoting.com --superuser --password="{{ config.sentry_admin_password }}"
+  shell: /home/sentry/venv/bin/sentry --config=/home/sentry/sentry.conf.py createuser --no-input --email='{{ config.sentry_admin_user }}' --superuser --password='{{ config.sentry_admin_password }}'
+  register: command_result
+  failed_when: "'already exists' not in command_result.stderr"

--- a/sentry/sentryconf.yml
+++ b/sentry/sentryconf.yml
@@ -9,18 +9,27 @@
   sudo: true
   sudo_user: sentry
   shell: /home/sentry/venv/bin/python /home/sentry/sentryconf.py chdir=/home/sentry/
+  register: dsn_contents
 
 - name: Sentry-AuthApi install raven
   sudo: true
   sudo_user: authapi
   shell: /home/authapi/env/bin/pip install raven
 
+- name: Sentry, creating deploy_sentry.py
+  sudo: true
+  sudo_user: authapi
+  template: src=sentry/templates/deploy_sentry.py dest=/home/authapi/authapi/authapi/authapi/deploy_sentry.py owner="authapi" mode=0644
+
 - name: Sentry, Configuring authapi
   sudo: true
-  sudo_user: root
-  shell: cat /tmp/authapi.sentry >> /home/authapi/authapi/authapi/authapi/deploy.py
+  sudo_user: authapi
+  lineinfile: dest=/home/authapi/authapi/authapi/authapi/deploy.py line="import authapi.deploy_sentry; authapi.deploy_sentry.update(globals())" state=present
 
-# restarting authapi
 - name: Sentry-AuthApi restarting authapi
   sudo: true
   supervisorctl: name=authapi state=restarted
+
+- name: Sentry-AuthApi restarting authapi_celery
+  sudo: true
+  supervisorctl: name=authapi_celery state=restarted

--- a/sentry/supervisor.yml
+++ b/sentry/supervisor.yml
@@ -9,8 +9,4 @@
 
 - name: Restarting supervisord
   sudo: true
-  service: name=supervisor state=stopped
-
-- name: Restarting supervisord
-  sudo: true
-  service: name=supervisor state=started
+  service: name=supervisor state=stopped sleep=6

--- a/sentry/templates/deploy_sentry.py
+++ b/sentry/templates/deploy_sentry.py
@@ -1,0 +1,75 @@
+# sentry
+
+# call to this function to update the globs globals variable: update(globals())
+def update(globs):
+    globs['RAVEN_CONFIG'] = dict(dsn='{{ dsn_contents.stderr }}')
+
+    if 'raven.contrib.django.raven_compat' not in globs['INSTALLED_APPS']:
+        globs['INSTALLED_APPS'] = globs['INSTALLED_APPS'] + (
+            'raven.contrib.django.raven_compat',
+        )
+
+{% if config.sentry_msg_log %}
+    globs['ADMINS'] = ( ('msg log', '{{ config.sentry_msg_log_email }}'), )
+    globs['SERVER_EMAIL'] = '{{ config.authapi_server_email }}'
+{% endif %}
+
+    globs['LOGGING'] = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'root': {
+        'level': 'WARNING',
+        'handlers': ['sentry'],
+    },
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+    },
+    'handlers': {
+{% if config.sentry_msg_log %}
+        'mail_admins': {
+            'level': 'INFO',
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+{% endif %}
+        'sentry': {
+            'level': 'INFO',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
+        }
+    },
+    'loggers': {
+        'django': {
+            'level': 'ERROR',
+            'handlers': ['sentry'],
+            'propagate': False,
+        },
+        'authapi': {
+            'level': 'INFO',
+            'handlers': ['sentry'],
+            'propagate': False,
+        },
+{% if config.sentry_msg_log %}
+        'authapi.notify': {
+            'level': 'INFO',
+            'handlers': ['sentry', 'mail_admins'],
+            'propagate': False,
+        },
+{% endif %}
+        'raven': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'sentry.errors': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+    },
+}

--- a/sentry/templates/sentry.conf.py
+++ b/sentry/templates/sentry.conf.py
@@ -22,7 +22,7 @@ SENTRY_USE_BIG_INTS = True
 # the beacon documentation for more information. This **must** be a string.
 
 # SENTRY_ADMIN_EMAIL = 'your.name@example.com'
-SENTRY_ADMIN_EMAIL = 'agora@agoravoting.com'
+SENTRY_ADMIN_EMAIL = '{{ config.sentry_admin_user }}'
 
 # Instruct Sentry that this install intends to be run by a single organization
 # and thus various UI optimizations should be enabled.
@@ -173,7 +173,7 @@ EMAIL_PORT = 25
 EMAIL_USE_TLS = False
 
 # The email address to send on behalf of
-SERVER_EMAIL = 'root@localhost'
+SERVER_EMAIL = '{{ config.sentry_admin_user }}'
 
 # If you're using mailgun for inbound mail, set your API key and configure a
 # route to forward to /api/hooks/mailgun/inbound/

--- a/sentry/templates/sentryconf.py
+++ b/sentry/templates/sentryconf.py
@@ -36,6 +36,11 @@ INSTALLED_APPS = INSTALLED_APPS + (
     'raven.contrib.django.raven_compat',
 )
 
+{% if config.sentry_msg_log %}
+ADMINS = ( ('msg log', '{{ config.sentry_msg_log_email }}'), )
+SERVER_EMAIL = '{{ config.authapi_server_email }}'
+{% endif %}
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': True,
@@ -49,6 +54,12 @@ LOGGING = {
         },
     },
     'handlers': {
+{% if config.sentry_msg_log %}
+        'mail_admins': {
+            'level': 'INFO',
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+{% endif %}
         'sentry': {
             'level': 'INFO',
             'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
@@ -70,6 +81,13 @@ LOGGING = {
             'handlers': ['sentry'],
             'propagate': False,
         },
+{% if config.sentry_msg_log %}
+        'authapi.notify': {
+            'level': 'INFO',
+            'handlers': ['sentry', 'mail_admins'],
+            'propagate': False,
+        },
+{% endif %}
         'raven': {
             'level': 'DEBUG',
             'handlers': ['console'],

--- a/sentry/templates/sentryconf.py
+++ b/sentry/templates/sentryconf.py
@@ -2,105 +2,35 @@
 from sentry.utils.runner import configure
 configure("/home/sentry/sentry.conf.py")
 
-# Do something crazy
+# Create the org, team and project if needed
 from sentry.models import Team, Project, ProjectKey, User, Organization
 
 user = User.objects.get(pk=1)
 
-organization = Organization()
-organization.name = 'AgoraVoting'
-organization.owner = user
-organization.save()
+name = 'AgoraVoting'
+name2 = 'AuthApi'
 
-team = Team()
-team.name = 'AgoraVoting'
-team.organization = organization
-team.save()
+if Organization.objects.filter(name=name, owner=user).count() == 0:
+    organization = Organization()
+    organization.name = name
+    organization.owner = user
+    organization.save()
 
-project = Project()
-project.team = team
-project.name = 'AuthApi'
-project.organization = organization
-project.save()
+    team = Team()
+    team.name = name
+    team.organization = organization
+    team.save()
+
+    project = Project()
+    project.team = team
+    project.name = name2
+    project.organization = organization
+    project.save()
+else:
+    organization = Organization.objects.filter(name=name, owner=user).all()[0]
+    team = Team.objects.filter(name=name, organization=organization).all()[0]
+    project =Project.objects.filter(team=team, name=name2, organization=organization).all()[0]
 
 key = ProjectKey.objects.filter(project=project)[0]
 dsn = key.get_dsn()
-
-# writting the sentry configuration to deploy.conf
-authapi_conf = '''
-# sentry
-RAVEN_CONFIG = {
-    'dsn': '%s',
-}
-INSTALLED_APPS = INSTALLED_APPS + (
-    'raven.contrib.django.raven_compat',
-)
-
-{% if config.sentry_msg_log %}
-ADMINS = ( ('msg log', '{{ config.sentry_msg_log_email }}'), )
-SERVER_EMAIL = '{{ config.authapi_server_email }}'
-{% endif %}
-
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': True,
-    'root': {
-        'level': 'WARNING',
-        'handlers': ['sentry'],
-    },
-    'formatters': {
-        'verbose': {
-            'format': '%%(levelname)s %%(asctime)s %%(module)s %%(process)d %%(thread)d %%(message)s'
-        },
-    },
-    'handlers': {
-{% if config.sentry_msg_log %}
-        'mail_admins': {
-            'level': 'INFO',
-            'class': 'django.utils.log.AdminEmailHandler'
-        },
-{% endif %}
-        'sentry': {
-            'level': 'INFO',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
-        },
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'verbose'
-        }
-    },
-    'loggers': {
-        'django': {
-            'level': 'ERROR',
-            'handlers': ['sentry'],
-            'propagate': False,
-        },
-        'authapi': {
-            'level': 'INFO',
-            'handlers': ['sentry'],
-            'propagate': False,
-        },
-{% if config.sentry_msg_log %}
-        'authapi.notify': {
-            'level': 'INFO',
-            'handlers': ['sentry', 'mail_admins'],
-            'propagate': False,
-        },
-{% endif %}
-        'raven': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-    },
-}
-'''
-
-with open('/tmp/authapi.sentry', 'w') as f:
-    f.write(authapi_conf % dsn)
+print(dsn)


### PR DESCRIPTION
If the config sentry_msg_log is set to true, the authapi log will be configured to send authapi.notify logs by email.

This is useful to trace email and sms sents to voters, we've the sentry log but we've another copy in the email inbox.