### PR TITLE
Fixed agora-verifier when provisioning.

### DIFF
--- a/agora-verifier/packages.yml
+++ b/agora-verifier/packages.yml
@@ -15,7 +15,7 @@
 
 - name: AgoraVerifier, Install sbt-0.13.7.deb
   sudo: true
-  apt: deb="/tmp/sbt-0.13.7.deb" state=present
+  apt: deb="/tmp/sbt-0.13.7.deb"
   when: sbt_check_deb.rc == 1
 
 - name: AgoraVerifier, Updating packages


### PR DESCRIPTION
I got this error in the next branch:

TASK: [AgoraVerifier, Install sbt-0.13.7.deb] ********************************* 
failed: [default] => {"failed": true}
msg: deb only supports state=installed

FATAL: all hosts have already failed -- aborting

With this change, this error disappear.
