### PR TITLE
fix aelections max body size, because play 2.3.x did not use play.htt…

### DIFF
--- a/agora-elections/templates/application.local.conf
+++ b/agora-elections/templates/application.local.conf
@@ -26,9 +26,11 @@ app.vote_callback_url="{{config.agora_elections.vote_callback.custom_url}}"
 # applied at once to:
 # play.http.parser.maxDiskBuffer (in agora-elections config)
 # play.http.parser.maxMemoryBuffer (in agora-elections config)
+# parsers.text.maxLength (in agora-elections config)
 # client_max_body_size (in nginx)
 play.http.parser.maxMemoryBuffer = {{config.http.max_body_size}}
 play.http.parser.maxDiskBuffer = {{config.http.max_body_size}}
+parsers.text.maxLength = {{config.http.max_body_size}}
 
 app.partial-tallies=false
 

--- a/config.yml
+++ b/config.yml
@@ -49,6 +49,7 @@ config:
     # applied at once to:
     # play.http.parser.maxDiskBuffer (in agora-elections config)
     # play.http.parser.maxMemoryBuffer (in agora-elections config)
+    # parsers.text.maxLength (in agora-elections config)
     # client_max_body_size (in nginx)
     max_body_size: 2m
 

--- a/doc/devel/agora.config.yml
+++ b/doc/devel/agora.config.yml
@@ -49,6 +49,7 @@ config:
     # applied at once to:
     # play.http.parser.maxDiskBuffer (in agora-elections config)
     # play.http.parser.maxMemoryBuffer (in agora-elections config)
+    # parsers.text.maxLength (in agora-elections config)
     # client_max_body_size (in nginx)
     max_body_size: 2m
 

--- a/doc/devel/auth1.config.yml
+++ b/doc/devel/auth1.config.yml
@@ -48,6 +48,7 @@ config:
     # applied at once to:
     # play.http.parser.maxDiskBuffer (in agora-elections config)
     # play.http.parser.maxMemoryBuffer (in agora-elections config)
+    # parsers.text.maxLength (in agora-elections config)
     # client_max_body_size (in nginx)
     max_body_size: 2m
 

--- a/doc/devel/auth2.config.yml
+++ b/doc/devel/auth2.config.yml
@@ -48,6 +48,7 @@ config:
     # applied at once to:
     # play.http.parser.maxDiskBuffer (in agora-elections config)
     # play.http.parser.maxMemoryBuffer (in agora-elections config)
+    # parsers.text.maxLength (in agora-elections config)
     # client_max_body_size (in nginx)
     max_body_size: 2m
 

--- a/doc/production/config.auth.yml
+++ b/doc/production/config.auth.yml
@@ -49,6 +49,7 @@ config:
     # applied at once to:
     # play.http.parser.maxDiskBuffer (in agora-elections config)
     # play.http.parser.maxMemoryBuffer (in agora-elections config)
+    # parsers.text.maxLength (in agora-elections config)
     # client_max_body_size (in nginx)
     max_body_size: 2m
 

--- a/doc/production/config.master.yml
+++ b/doc/production/config.master.yml
@@ -49,6 +49,7 @@ config:
     # applied at once to:
     # play.http.parser.maxDiskBuffer (in agora-elections config)
     # play.http.parser.maxMemoryBuffer (in agora-elections config)
+    # parsers.text.maxLength (in agora-elections config)
     # client_max_body_size (in nginx)
     max_body_size: 2m
 


### PR DESCRIPTION
…p.parser.maxMemoryBuffer, only parsers.text.maxLength