### PR TITLE
oneserver: Add simple http auth optional configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -25,8 +25,8 @@ params:
 
 # global configuration
 config:
-  version: 103111.8
   backup_password: '<PASSWORD>'
+  version: 103111.9
 
   # global config. Note: currently some other keys are used as global conf
   global_secret_key: '<PASSWORD>'
@@ -167,6 +167,12 @@ config:
     # election authorities. This way, you can use one certificate publicly
     # and another internaly.
     internal_tls_calist_path: /srv/certs/selfsigned/calist
+
+    # Simple http authentication protection for all services under nginx.
+    # http_auth:
+    #   user: admin
+    #   password: eengiefe
+    http_auth: false
 
   # some java related configuration options
   java:

--- a/doc/devel/agora.config.yml
+++ b/doc/devel/agora.config.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 103111.8
+  version: 103111.9
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -167,6 +167,12 @@ config:
     # election authorities. This way, you can use one certificate publicly
     # and another internaly.
     internal_tls_calist_path: /srv/certs/selfsigned/calist
+
+    # Simple http authentication protection for all services under nginx.
+    # http_auth:
+    #   user: admin
+    #   password: eengiefe
+    http_auth: false
 
   # some java related configuration options
   java:

--- a/doc/devel/auth1.config.yml
+++ b/doc/devel/auth1.config.yml
@@ -24,7 +24,7 @@ params:
     slow: 15
 
 config:
-  version: 103111.8
+  version: 103111.9
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -166,6 +166,12 @@ config:
     # election authorities. This way, you can use one certificate publicly
     # and another internaly.
     internal_tls_calist_path: /srv/certs/selfsigned/calist
+
+    # Simple http authentication protection for all services under nginx.
+    # http_auth:
+    #   user: admin
+    #   password: eengiefe
+    http_auth: false
 
   # some java related configuration options
   java:

--- a/doc/devel/auth2.config.yml
+++ b/doc/devel/auth2.config.yml
@@ -24,7 +24,7 @@ params:
     slow: 15
 
 config:
-  version: 103111.8
+  version: 103111.9
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -166,6 +166,12 @@ config:
     # election authorities. This way, you can use one certificate publicly
     # and another internaly.
     internal_tls_calist_path: /srv/certs/selfsigned/calist
+
+    # Simple http authentication protection for all services under nginx.
+    # http_auth:
+    #   user: admin
+    #   password: eengiefe
+    http_auth: false
 
   # some java related configuration options
   java:

--- a/doc/production/config.auth.yml
+++ b/doc/production/config.auth.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 103111.8
+  version: 103111.9
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -167,6 +167,12 @@ config:
     # election authorities. This way, you can use one certificate publicly
     # and another internaly.
     internal_tls_calist_path: /srv/certs/selfsigned/calist
+
+    # Simple http authentication protection for all services under nginx.
+    # http_auth:
+    #   user: admin
+    #   password: eengiefe
+    http_auth: false
 
   # some java related configuration options
   java:

--- a/doc/production/config.master.yml
+++ b/doc/production/config.master.yml
@@ -25,7 +25,7 @@ params:
 
 # global configuration
 config:
-  version: 103111.8
+  version: 103111.9
   backup_password: '<PASSWORD>'
 
   # global config. Note: currently some other keys are used as global conf
@@ -167,6 +167,12 @@ config:
     # election authorities. This way, you can use one certificate publicly
     # and another internaly.
     internal_tls_calist_path: /srv/certs/selfsigned/calist
+
+    # Simple http authentication protection for all services under nginx.
+    # http_auth:
+    #   user: admin
+    #   password: eengiefe
+    http_auth: false
 
   # some java related configuration options
   java:

--- a/oneserver/main.yml
+++ b/oneserver/main.yml
@@ -92,3 +92,8 @@
 - name: OneServer, Restarting nginx
   become: true
   service: name=nginx state=restarted
+
+- name: OneServer, http authentication
+  become: true
+  shell: echo "{{config.http.http_auth.user}}:$(openssl passwd -crypt {{config.http.http_auth.password}})" > /etc/nginx/.htpasswd
+  when: config.http.http_auth

--- a/oneserver/templates/nginx.conf
+++ b/oneserver/templates/nginx.conf
@@ -123,6 +123,11 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
+
+    {% if config.http.http_auth %}
+    auth_basic "Restricted Content";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+    {% endif %}
 }
 
 

--- a/oneserver/templates/nginx.conf
+++ b/oneserver/templates/nginx.conf
@@ -123,11 +123,6 @@ http {
 
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;
-
-    {% if config.http.http_auth %}
-    auth_basic "Restricted Content";
-    auth_basic_user_file /etc/nginx/.htpasswd;
-    {% endif %}
 }
 
 

--- a/oneserver/templates/oneserver.conf
+++ b/oneserver/templates/oneserver.conf
@@ -67,6 +67,11 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        {% if config.http.http_auth %}
+        auth_basic "Restricted Content";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        {% endif %}
     }
 
     location /booth/ {
@@ -76,6 +81,11 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        {% if config.http.http_auth %}
+        auth_basic "Restricted Content";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        {% endif %}
     }
 
     location /election/ {
@@ -85,6 +95,11 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        {% if config.http.http_auth %}
+        auth_basic "Restricted Content";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        {% endif %}
     }
 
     # authapi


### PR DESCRIPTION
If the config http_auth exists the http_auth.user and http_auth.password
are stored in the /etc/nginx/.htpasswd file and used as authentication
for all resources provided by nginx.

If the http_auth is false it works as usual.