### PR TITLE
The application.local.conf configuration created by agora-dev-box was…

### DIFF
--- a/agora-elections/templates/application.local.conf
+++ b/agora-elections/templates/application.local.conf
@@ -1,7 +1,7 @@
 db.default.url="jdbc:postgresql://{{ config.load_balancing.slave.master_hostname if not config.load_balancing.is_master else 'localhost' }}:5432/agora_elections"
 db.default.driver="org.postgresql.Driver"
 db.default.user=agora_elections
-db.default.pass={{config.agora_elections.db_password}}
+db.default.pass="{{config.agora_elections.db_password}}"
 
 app.datastore.public="/home/agoraelections/datastore/public"
 app.datastore.private="/home/agoraelections/datastore/private"
@@ -110,7 +110,7 @@ app.authorities = {
 
 app.eopeers.dir=/etc/eopeers/
 
-booth.auth.secret={{config.agora_elections.shared_secret}}
+booth.auth.secret="{{config.agora_elections.shared_secret}}"
 booth.auth.expiry={{config.agora_elections.expiry}}
 
 ws.ssl {


### PR DESCRIPTION
… not quoting the shared_secret and this created a runtime error when launching when using secrets with characters like *