### PR TITLE
Fix PDF creation in agora-results

### DIFF
--- a/agora-elections/templates/results.req.txt
+++ b/agora-elections/templates/results.req.txt
@@ -1,3 +1,5 @@
 -e git+{{ repos.tally.repo }}@{{ repos.tally.version }}#egg=agora-tally
-reportlab==3.3.0
-requests==2.12.3
+reportlab==3.5.55
+requests==2.20.0
+pytz==2021.3
+Babel==2.9.1


### PR DESCRIPTION
PDF results generation is failing because `pytz==2021.3` dependency is missing from `requirements.txt` virtualenv used for agora-results in agora-elections.